### PR TITLE
T565 商品页面index.html.erb的整张卡片都能链接到商品详情页

### DIFF
--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -84,6 +84,14 @@
   -webkit-box-orient: vertical;
 }
 
+
+.card .title > li > a:hover, {
+text-decoration:none;
+}
+.card .title > li > a:focus, {
+text-decoration:none;
+}
+
 .card .description {
   margin-right: 25px;
   padding: 0 12px 0;

--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -85,10 +85,7 @@
 }
 
 
-.card .title > li > a:hover, {
-text-decoration:none;
-}
-.card .title > li > a:focus, {
+.product-path:hover{
 text-decoration:none;
 }
 

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -8,15 +8,16 @@
       <div class="row">
         <% @products.each do |product| %>
           <div class="col-xs-12 col-xs-3">
+            <%= link_to product_path(product) do %>
             <div class="fathercard">
             <div class="card">
-            <%= link_to product_path(product) do %>
+
               <% if product.image.present? %>
                 <%= image_tag(product.image.thumb.url, class: "thumbnail") %>
               <% else %>
                 <%= image_tag("http://placehold.it/200x200&text=No Pic", class: "thumbnail") %>
               <% end %>
-            <% end %>
+
               <ol>
                 <div class="title">
                    <%= product.title %>
@@ -32,6 +33,7 @@
                 </div>
             </div>
             </div>
+            <% end %>
           </div>
         <% end %>
       </div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -11,13 +11,11 @@
             <%= link_to product_path(product), class: "product-path" do %>
             <div class="fathercard">
             <div class="card">
-
               <% if product.image.present? %>
                 <%= image_tag(product.image.thumb.url, class: "thumbnail") %>
               <% else %>
                 <%= image_tag("http://placehold.it/200x200&text=No Pic", class: "thumbnail") %>
               <% end %>
-
               <ol>
                 <div class="title">
                    <%= product.title %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -8,7 +8,7 @@
       <div class="row">
         <% @products.each do |product| %>
           <div class="col-xs-12 col-xs-3">
-            <%= link_to product_path(product) do %>
+            <%= link_to product_path(product), class: "product-path" do %>
             <div class="fathercard">
             <div class="card">
 

--- a/app/views/products/welcome_show.html.erb
+++ b/app/views/products/welcome_show.html.erb
@@ -41,15 +41,14 @@
       <div class="row">
         <% @product_hots.each do |product| %>
           <div class="col-xs-12 col-xs-3">
+            <%= link_to product_path(product), class: "product-path" do %>
             <div class="fathercard">
             <div class="card">
-            <%= link_to product_path(product) do %>
               <% if product.image.present? %>
                 <%= image_tag(product.image.url, class: "thumbnail") %>
               <% else %>
                 <%= image_tag("http://placehold.it/200x200&text=No Pic", class: "thumbnail") %>
               <% end %>
-            <% end %>
               <ol>
                 <div class="title">
                    <%= product.title %>
@@ -65,6 +64,7 @@
                 </div>
             </div>
             </div>
+            <% end %>
           </div>
         <% end %>
       </div>
@@ -80,15 +80,14 @@
       <div class="row">
         <% @product_xians.each do |product| %>
           <div class="col-xs-12 col-xs-3">
+            <%= link_to product_path(product), class: "product-path" do %>
             <div class="fathercard">
             <div class="card">
-            <%= link_to product_path(product) do %>
               <% if product.image.present? %>
                 <%= image_tag(product.image.url, class: "thumbnail") %>
               <% else %>
                 <%= image_tag("http://placehold.it/200x200&text=No Pic", class: "thumbnail") %>
               <% end %>
-            <% end %>
               <ol>
                 <div class="title">
                    <%= product.title %>
@@ -104,6 +103,7 @@
                 </div>
             </div>
             </div>
+            <% end %>
           </div>
         <% end %>
       </div>
@@ -119,15 +119,14 @@
       <div class="row">
         <% @product_xias.each do |product| %>
           <div class="col-xs-12 col-xs-3">
+            <%= link_to product_path(product), class: "product-path" do %>
             <div class="fathercard">
             <div class="card">
-            <%= link_to product_path(product) do %>
               <% if product.image.present? %>
                 <%= image_tag(product.image.url, class: "thumbnail") %>
               <% else %>
                 <%= image_tag("http://placehold.it/200x200&text=No Pic", class: "thumbnail") %>
               <% end %>
-            <% end %>
               <ol>
                 <div class="title">
                    <%= product.title %>
@@ -143,6 +142,7 @@
                 </div>
             </div>
             </div>
+            <% end %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## Issue Link

* https://app.clubhouse.io/jystore/story/565
## Changes

使商品页面index.html.erb的整张卡片都能链接到商品详情页,之前只有卡片上的图片可以链接到商品详情页

## Screenshots

(功能画面截图，不需要可删除)
